### PR TITLE
Fix validation check for attack4 in substruct_A

### DIFF
--- a/substruct_A.py
+++ b/substruct_A.py
@@ -45,7 +45,7 @@ def substruct_A(attack1, attack1_PP = 0, attack2 = None, attack2_PP = 0, attack3
     if attack3 != None and attack3 not in attack_Dict:
         print ("Invalid attack 3:", attack3)
         error = 1
-    if attack4 != None and attack1 not in attack_Dict:
+    if attack4 != None and attack4 not in attack_Dict:
         print ("Invalid attack 4:", attack4)
         error = 1
     if error == 1:


### PR DESCRIPTION
### Motivation
- Correct a bug where the `attack4` validation erroneously checked `attack1`, causing valid or invalid `attack4` values to be misreported.

### Description
- Change the condition from `if attack4 != None and attack1 not in attack_Dict:` to `if attack4 != None and attack4 not in attack_Dict:` in `substruct_A` so the correct variable is validated.

### Testing
- Ran the project's unit tests and a targeted check invoking `substruct_A` with both valid and invalid `attack4` inputs; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f15fb4c00832998683ae004b2a98f)