### PR TITLE
Fix pk3_Info crash when PID_Search returns None

### DIFF
--- a/pk3_Info.py
+++ b/pk3_Info.py
@@ -7,10 +7,11 @@ accepted_languages = ["international", "english", "0202", "french", "0203", "ita
 def pk3_Info(pokemon, pokemon_ID, OT_Name = None, trainer_ID = None, trainer_SID = None, language = "0202", nickname = None, circle = False, square = False, triangle = False, heart = False):
     # - - - Sanitize inputs - - -
     error = 0
+    PID_Data = PID_Search(pokemon_ID)
     if dex_Search(pokemon) == None:
         print ("Invalid \"pokemon\" str/int:", pokemon)
         error = 1
-    if (PID_Search(pokemon_ID)[1])[0] == None:
+    if PID_Data == None or (PID_Data[1])[0] == None:
         print ("Invalid \"pokemon_ID\" int/str:", pokemon_ID)
         error = 1
     if OT_Name == None:
@@ -91,7 +92,7 @@ def pk3_Info(pokemon, pokemon_ID, OT_Name = None, trainer_ID = None, trainer_SID
         return None
     # - - - Done sanitizing inputs - - -
     PID_Little = str()
-    for PID_Byte in (int((PID_Search(pokemon_ID)[1])[0], 16).to_bytes(4, 'little')):
+    for PID_Byte in (int((PID_Data[1])[0], 16).to_bytes(4, 'little')):
         PID_Little = PID_Little + hex(PID_Byte)[2:].zfill(2)
     TID_Full = hex(trainer_SID)[2:] + hex(trainer_ID)[2:]
     TID_Little = str()


### PR DESCRIPTION
### Motivation
- Prevent a `TypeError` in `pk3_Info` when `PID_Search(pokemon_ID)` returns `None` so invalid PID input follows the normal validation flow instead of crashing.
- Keep the existing validation and output style intact while avoiding repeated lookups of PID data.

### Description
- Cache the result of `PID_Search(pokemon_ID)` in `PID_Data` at the start of validation and check `PID_Data` for `None` before indexing into it.
- Treat `PID_Data == None` (or missing PID bytes) as invalid `pokemon_ID` input and set the validation error accordingly.
- Reuse the cached `PID_Data` when constructing `PID_Little` to avoid calling `PID_Search` again.

### Testing
- Ran `python -m py_compile pk3_Info.py` which completed successfully.
- Executed `pk3_Info('Pikachu', 'not_a_pid', OT_Name='ASH', trainer_ID=12345, trainer_SID=54321)` and observed the function return `None` with validation messages and no `TypeError` crash.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f2934ff148329a758c944c474d120)