### PR TITLE
Use bitwise flags for Gen 3 markings in pk3_Info.py

### DIFF
--- a/pk3_Info.py
+++ b/pk3_Info.py
@@ -98,15 +98,16 @@ def pk3_Info(pokemon, pokemon_ID, OT_Name = None, trainer_ID = None, trainer_SID
     TID_Little = str()
     for TID_Byte in (int(TID_Full, 16).to_bytes(4, 'little')):
         TID_Little = TID_Little + hex(TID_Byte)[2:].zfill(2)
+    # Gen 3 mark bits: circle=bit0, triangle=bit1, square=bit2, heart=bit3
     markings = 0
     if circle == True:
-        markings = markings + 0
-    if square == True:
-        markings = markings + 0
+        markings |= 0x1
     if triangle == True:
-        markings = markings + 0
+        markings |= 0x2
+    if square == True:
+        markings |= 0x4
     if heart == True:
-        markings = markings + 0
+        markings |= 0x8
     if nickname == None:
         return (PID_Little.upper() + TID_Little.upper() + translate(dex_Search(pokemon, return_Upper = True)[0], 10, language).upper() + language.upper() + translate(OT_Name, 7, language).upper() + hex(markings)[2:].zfill(2).upper() + "CHCK" + "0000".upper())
     if nickname != None:


### PR DESCRIPTION
### Motivation
- The previous code used no-op additions (`markings = markings + 0`) and did not actually encode Gen 3 marking flags. 
- Replace the placeholder branches with a stable, documented bit layout so markings serialize correctly while keeping existing output format.

### Description
- Replaced the four `markings = markings + 0` branches with bitwise flag assignments using `|=` in `pk3_Info.py`.
- Added a comment documenting the Gen 3 bit layout: `circle=0x1`, `triangle=0x2`, `square=0x4`, and `heart=0x8`.
- Left the existing serialization unchanged by continuing to use `hex(markings)[2:].zfill(2).upper()` so output formatting remains the same.

### Testing
- Compiled the updated module with `python -m py_compile pk3_Info.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f2ea39a188329884263578e18ec9a)