### PR TITLE
Use normalized `lang` variable for language validation and mapping in pk3_Info

### DIFF
--- a/pk3_Info.py
+++ b/pk3_Info.py
@@ -57,21 +57,22 @@ def pk3_Info(pokemon, pokemon_ID, OT_Name = None, trainer_ID = None, trainer_SID
         error = 1
     if trainer_SID != None and type(trainer_SID) != int:
         print ("Invalid \"trainer_SID\" int:", trainer_ID)
-    if language.lower() not in accepted_languages:
+    lang = language.lower()
+    if lang not in accepted_languages:
         print ("Invalid \"language\" string:", language)
         error = 1
-    if language.lower() == "japanese":
+    if lang == "japanese":
         language = "0201"
-    if language.lower() == "international" or language == "english":
+    if lang == "international" or lang == "english":
         language = "0202"
-    if language.lower() == "french":
+    if lang == "french":
         language = "0203"
-    if language.lower() == "italian":
+    if lang == "italian":
         language = "0204"
-    if language.lower() == "german":
+    if lang == "german":
         language = "0205"
-    if language.lower() == "spanish":
-            language = "0207"
+    if lang == "spanish":
+        language = "0207"
     if nickname != None and translate(nickname) == None:
         print("Invalid \"nickname\" str:", nickname)
         error = 1


### PR DESCRIPTION
### Motivation
- Normalize language comparisons by computing `language.lower()` once to avoid repeated calls and make the validation/mapping logic clearer.

### Description
- Introduces `lang = language.lower()` and uses `lang` for the `accepted_languages` check and subsequent language-to-code mappings, then assigns the mapped code back to `language`; also cleans up indentation on the Spanish mapping line.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0791a0ce08329994d976a3bd0c42e)