### PR TITLE
Fix Gen 3 Pokémon marking bits order

### DIFF
--- a/pk3_Info.py
+++ b/pk3_Info.py
@@ -91,13 +91,13 @@ def pk3_Info(pokemon, pokemon_ID, OT_Name = None, trainer_ID = None, trainer_SID
     TID_Little = str()
     for TID_Byte in (int(TID_Full, 16).to_bytes(4, 'little')):
         TID_Little = TID_Little + hex(TID_Byte)[2:].zfill(2)
-    # Gen 3 mark bits: circle=bit0, triangle=bit1, square=bit2, heart=bit3
+    # Gen 3 mark bits: circle=bit0, square=bit1, triangle=bit2, heart=bit3
     markings = 0
     if circle == True:
         markings |= 0x1
-    if triangle == True:
-        markings |= 0x2
     if square == True:
+        markings |= 0x2
+    if triangle == True:
         markings |= 0x4
     if heart == True:
         markings |= 0x8


### PR DESCRIPTION
## Summary
Corrected the bit assignment order for Pokémon markings in Generation 3 to match the actual game mechanics.

## Changes
- Updated the comment documenting Gen 3 marking bits to reflect the correct order: circle=bit0, square=bit1, triangle=bit2, heart=bit3
- Reordered the marking bit assignments to match the corrected specification:
  - Square marking now uses bit 1 (0x2) instead of bit 2
  - Triangle marking now uses bit 2 (0x4) instead of bit 1
  - Circle and heart markings remain unchanged

## Details
The previous implementation had square and triangle markings swapped. This fix ensures that the marking bits are correctly assigned according to Generation 3 Pokémon game specifications.

https://claude.ai/code/session_01NANZ1JoDnA8h5pFgWF1ZM3